### PR TITLE
feat: Adiciona pesquisa de estabelecimento por parametros

### DIFF
--- a/src/main/java/io/bootify/quickcheck/repos/FuncionarioRepository.java
+++ b/src/main/java/io/bootify/quickcheck/repos/FuncionarioRepository.java
@@ -5,6 +5,8 @@ import io.bootify.quickcheck.domain.Funcionario;
 import io.bootify.quickcheck.domain.Usuario;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 
 public interface FuncionarioRepository extends JpaRepository<Funcionario, Long> {
 
@@ -14,4 +16,9 @@ public interface FuncionarioRepository extends JpaRepository<Funcionario, Long> 
 
     boolean existsByUsuarioId(Long id);
 
+    List<Funcionario> findAllByEspecialidadeAndEstabelecimentoUsuarioNomeContainingAndEstabelecimentoTipo(
+            String especialidade,
+            String estabelecimentoNome,
+            String estabelecimentoTipo
+    );
 }

--- a/src/main/java/io/bootify/quickcheck/rest/FuncionarioResource.java
+++ b/src/main/java/io/bootify/quickcheck/rest/FuncionarioResource.java
@@ -63,4 +63,13 @@ public class FuncionarioResource {
         return ResponseEntity.noContent().build();
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<List<FuncionarioDTO>> getAllByEspecialidadeAndEstabelecimentoNomeLikeAndEstabelecimentoTipo(
+            @RequestParam String especialidade,
+            @RequestParam String estabelecimentoNome,
+            @RequestParam String estabelecimentoTipo
+    ) {
+        return ResponseEntity.ok(funcionarioService
+                .findAllByEspecialidadeAndEstabelecimentoNomeLikeAndEstabelecimentoTipo(especialidade, estabelecimentoNome, estabelecimentoTipo));
+    }
 }

--- a/src/main/java/io/bootify/quickcheck/service/FuncionarioService.java
+++ b/src/main/java/io/bootify/quickcheck/service/FuncionarioService.java
@@ -1,7 +1,6 @@
 package io.bootify.quickcheck.service;
 
 import io.bootify.quickcheck.domain.*;
-import io.bootify.quickcheck.model.ClienteDTO;
 import io.bootify.quickcheck.model.FuncionarioDTO;
 import io.bootify.quickcheck.repos.EstabelecimentoRepository;
 import io.bootify.quickcheck.repos.FuncionarioRepository;
@@ -112,5 +111,15 @@ public class FuncionarioService {
     public FuncionarioDTO getFuncionarioByUsuario(Usuario usuario) {
         Funcionario funcionario = funcionarioRepository.findFirstByUsuario(usuario);
         return mapToDTO(funcionario, new FuncionarioDTO());
+    }
+
+    public List<FuncionarioDTO> findAllByEspecialidadeAndEstabelecimentoNomeLikeAndEstabelecimentoTipo(String especialidade,
+                                                                                                       String estabelecimentoNome,
+                                                                                                       String estabelecimentoTipo) {
+        final List<Funcionario> funcionarios = funcionarioRepository
+                .findAllByEspecialidadeAndEstabelecimentoUsuarioNomeContainingAndEstabelecimentoTipo(especialidade, estabelecimentoNome, estabelecimentoTipo);
+        return funcionarios.stream()
+                .map(funcionario -> mapToDTO(funcionario, new FuncionarioDTO()))
+                .toList();
     }
 }


### PR DESCRIPTION
Adiciona pesquisa de estabelecimento por parâmetros

É possível pesquisar o estabelecimento passando a especialidade do médico, o nome do hospital e o tipo de hospital

O nome não precisa ser exato, pode ser aproximado (já que o usuário nem sempre vai digitar o nome corretamente)

Exemplo:

`localhost:8080/api/funcionarios/search?especialidade=Cardiologia&estabelecimentoNome=Hospital Port&estabelecimentoTipo=Hospital Geral`