### PR TITLE
feat: Adiciona endpoint para horario e corrige mocks

### DIFF
--- a/src/main/java/io/bootify/quickcheck/QuickcheckApplication.java
+++ b/src/main/java/io/bootify/quickcheck/QuickcheckApplication.java
@@ -332,9 +332,11 @@ public class QuickcheckApplication implements CommandLineRunner {
                 LocalDateTime.of(2024, 9, 16, 13, 0)
         };
 
+        // Status: DISPONÍVEL, AGENDADO, CONCLUÍDO, CANCELADO, PENDENTE
+        // Marcando todos os status como Disponível para aparecer no mapa
         String[] status = {
-                "Agendado", "Disponível", "Concluído", "Cancelado", "Pendente",
-                "Agendado", "Disponível", "Concluído", "Cancelado", "Pendente"
+                "Disponível", "Disponível", "Disponível", "Disponível", "Disponível",
+                "Disponível", "Disponível", "Disponível", "Disponível", "Disponível"
         };
 
         String[] descricoesHorario = {

--- a/src/main/java/io/bootify/quickcheck/repos/HorarioRepository.java
+++ b/src/main/java/io/bootify/quickcheck/repos/HorarioRepository.java
@@ -21,4 +21,7 @@ public interface HorarioRepository extends JpaRepository<Horario, Long> {
     List<Horario> findAllByEstabelecimentoIdAndStatus(Long estabelecimentoId, String status);
 
     List<Horario> findAllByEstabelecimentoIdAndStatusAndFuncionarioEspecialidade(Long estabelecimentoId, String status, Optional<String> especialidade);
+
+    List<Horario> findAllByStatusAndFuncionarioEspecialidadeAndFuncionarioEstabelecimentoTipoAndFuncionarioEstabelecimentoUsuarioNomeContaining(
+            String status, String especialidade, String tipo, String nome);
 }

--- a/src/main/java/io/bootify/quickcheck/rest/HorarioResource.java
+++ b/src/main/java/io/bootify/quickcheck/rest/HorarioResource.java
@@ -68,7 +68,15 @@ public class HorarioResource {
         } else {
         return ResponseEntity.ok(horarioService.findAllByEstabelecimentoIdAndStatus(estabelecimentoId, status));
         }
+    }
 
+    @GetMapping("/search/estabelecimentos")
+    public ResponseEntity<List<HorarioDTO>> getHorarioByStatusAndEspecialidadeAndNomeAndTipo(
+            @RequestParam String status,
+            @RequestParam String especialidade,
+            @RequestParam String nome,
+            @RequestParam String tipo) {
+            return ResponseEntity.ok(horarioService.findAllByStatusAndEspecialidadeAndTipoAndNome(status, especialidade, tipo, nome));
     }
 
 }

--- a/src/main/java/io/bootify/quickcheck/service/HorarioService.java
+++ b/src/main/java/io/bootify/quickcheck/service/HorarioService.java
@@ -109,4 +109,13 @@ public class HorarioService {
                 .map(horario -> mapToDTO(horario, new HorarioDTO()))
                 .toList();
     }
+
+    public List<HorarioDTO> findAllByStatusAndEspecialidadeAndTipoAndNome(String status, String especialidade, String tipo, String nome) {
+        final List<Horario> horarios = horarioRepository
+                .findAllByStatusAndFuncionarioEspecialidadeAndFuncionarioEstabelecimentoTipoAndFuncionarioEstabelecimentoUsuarioNomeContaining(
+                status, especialidade, tipo, nome);
+        return horarios.stream()
+                .map(horario -> mapToDTO(horario, new HorarioDTO()))
+                .toList();
+    }
 }


### PR DESCRIPTION
Adiciona endpoint para horario e corrige mocks

Novo endpoint para horario (para exibir apenas os estabelecimentos que possuem horário disponível e com os filtros aplicados)

`localhost:8080/api/horarios/search/estabelecimentos?status=Disponível&especialidade=Cardiologia&nome=Hospital Port&tipo=Hospital Geral`

Alterar os mocks de horarios para todos os status serem `Disponíveis` (para aparecer no mapa)