### PR TITLE
chore: Remove atributo idade de Cliente e Funcionario

### DIFF
--- a/src/main/java/io/bootify/quickcheck/QuickcheckApplication.java
+++ b/src/main/java/io/bootify/quickcheck/QuickcheckApplication.java
@@ -216,8 +216,6 @@ public class QuickcheckApplication implements CommandLineRunner {
                 "67890123456", "78901234567", "89012345678", "90123456789", "01234567890"
         };
 
-        Integer[] idades = {25, 32, 45, 28, 50, 37, 22, 30, 40, 29};
-
         LocalDate[] nascimentos = {
                 LocalDate.of(1998, 5, 12), LocalDate.of(1991, 3, 8), LocalDate.of(1978, 10, 15),
                 LocalDate.of(1995, 12, 30), LocalDate.of(1973, 7, 23), LocalDate.of(1986, 11, 2),
@@ -399,7 +397,6 @@ public class QuickcheckApplication implements CommandLineRunner {
                 cliente.setComorbidades(comorbidades[i]);
                 cliente.setCpf(cpfs[i]);
                 cliente.setSexo(sexos[i]);
-                cliente.setIdade(idades[i]);
                 cliente.setLatitude(latitudes[i]);
                 cliente.setLongitude(longitudes[i]);
                 cliente.setNascimento(nascimentos[i]);
@@ -446,7 +443,6 @@ public class QuickcheckApplication implements CommandLineRunner {
                 Funcionario funcionario = new Funcionario();
                 funcionario.setCpf(cpfs[i]);
                 funcionario.setSexo(sexos[i]);
-                funcionario.setIdade(idades[i]);
                 funcionario.setNascimento(nascimentos[i]);
                 funcionario.setCrm(crms[i]);
                 funcionario.setEspecialidade(especialidades[i]);

--- a/src/main/java/io/bootify/quickcheck/domain/Cliente.java
+++ b/src/main/java/io/bootify/quickcheck/domain/Cliente.java
@@ -40,9 +40,6 @@ public class Cliente {
     private String cpf;
 
     @Column(nullable = false)
-    private Integer idade;
-
-    @Column(nullable = false)
     private LocalDate nascimento;
 
     @Column(nullable = false, length = 1)

--- a/src/main/java/io/bootify/quickcheck/domain/Funcionario.java
+++ b/src/main/java/io/bootify/quickcheck/domain/Funcionario.java
@@ -37,9 +37,6 @@ public class Funcionario {
     private String cpf;
 
     @Column(nullable = false)
-    private Integer idade;
-
-    @Column(nullable = false)
     private LocalDate nascimento;
 
     @Column(nullable = false, length = 1)

--- a/src/main/java/io/bootify/quickcheck/model/ClienteDTO.java
+++ b/src/main/java/io/bootify/quickcheck/model/ClienteDTO.java
@@ -20,9 +20,6 @@ public class ClienteDTO {
     private String cpf;
 
     @NotNull
-    private Integer idade;
-
-    @NotNull
     private LocalDate nascimento;
 
     @NotNull

--- a/src/main/java/io/bootify/quickcheck/model/FuncionarioDTO.java
+++ b/src/main/java/io/bootify/quickcheck/model/FuncionarioDTO.java
@@ -20,9 +20,6 @@ public class FuncionarioDTO {
     private String cpf;
 
     @NotNull
-    private Integer idade;
-
-    @NotNull
     private LocalDate nascimento;
 
     @NotNull

--- a/src/main/java/io/bootify/quickcheck/service/ClienteService.java
+++ b/src/main/java/io/bootify/quickcheck/service/ClienteService.java
@@ -61,7 +61,6 @@ public class ClienteService {
     private ClienteDTO mapToDTO(final Cliente cliente, final ClienteDTO clienteDTO) {
         clienteDTO.setId(cliente.getId());
         clienteDTO.setCpf(cliente.getCpf());
-        clienteDTO.setIdade(cliente.getIdade());
         clienteDTO.setNascimento(cliente.getNascimento());
         clienteDTO.setSexo(cliente.getSexo());
         clienteDTO.setLatitude(cliente.getLatitude());
@@ -74,7 +73,6 @@ public class ClienteService {
 
     private Cliente mapToEntity(final ClienteDTO clienteDTO, final Cliente cliente) {
         cliente.setCpf(clienteDTO.getCpf());
-        cliente.setIdade(clienteDTO.getIdade());
         cliente.setNascimento(clienteDTO.getNascimento());
         cliente.setSexo(clienteDTO.getSexo());
         cliente.setLatitude(clienteDTO.getLatitude());

--- a/src/main/java/io/bootify/quickcheck/service/FuncionarioService.java
+++ b/src/main/java/io/bootify/quickcheck/service/FuncionarioService.java
@@ -64,7 +64,6 @@ public class FuncionarioService {
             final FuncionarioDTO funcionarioDTO) {
         funcionarioDTO.setId(funcionario.getId());
         funcionarioDTO.setCpf(funcionario.getCpf());
-        funcionarioDTO.setIdade(funcionario.getIdade());
         funcionarioDTO.setNascimento(funcionario.getNascimento());
         funcionarioDTO.setSexo(funcionario.getSexo());
         funcionarioDTO.setEspecialidade(funcionario.getEspecialidade());
@@ -77,7 +76,6 @@ public class FuncionarioService {
     private Funcionario mapToEntity(final FuncionarioDTO funcionarioDTO,
             final Funcionario funcionario) {
         funcionario.setCpf(funcionarioDTO.getCpf());
-        funcionario.setIdade(funcionarioDTO.getIdade());
         funcionario.setNascimento(funcionarioDTO.getNascimento());
         funcionario.setSexo(funcionarioDTO.getSexo());
         funcionario.setEspecialidade(funcionarioDTO.getEspecialidade());


### PR DESCRIPTION
Remove atributo idade de Cliente e Funcionario

Considerando que já temos o atributo `nascimento `e que é possível calcular a idade a partir da data de nascimento, não é necessário salvar a idade no banco de dados