### PR TITLE
chore: Permitir horario agendamento ser nulo

### DIFF
--- a/src/main/java/io/bootify/quickcheck/domain/Horario.java
+++ b/src/main/java/io/bootify/quickcheck/domain/Horario.java
@@ -32,7 +32,6 @@ public class Horario {
     @Column(nullable = false)
     private LocalDateTime horarioAtendimento;
 
-    @Column(nullable = false)
     private LocalDateTime horarioAgendamento;
 
     @Column(nullable = false)

--- a/src/main/java/io/bootify/quickcheck/model/HorarioDTO.java
+++ b/src/main/java/io/bootify/quickcheck/model/HorarioDTO.java
@@ -19,7 +19,6 @@ public class HorarioDTO {
     @NotNull
     private LocalDateTime horarioAtendimento;
 
-    @NotNull
     private LocalDateTime horarioAgendamento;
 
     @NotNull


### PR DESCRIPTION
Permitir horário agendamento ser nulo (para criar um novo agendamento só com o horário de atendimento)